### PR TITLE
[filesystem] Create minimal root filesystem layout

### DIFF
--- a/docs/create-filesystem.md
+++ b/docs/create-filesystem.md
@@ -1,0 +1,26 @@
+## File System 
+A Linux system expects a specific directory hierarchy. We'll create our root filesystem from scratch, closely mimicking what a real Linux distribution would use, while keeping it minimal.
+
+**Example layout:**
+
+Mini_linux/
+
+    └── root/
+
+        ├── boot/
+    
+        ├── proc/
+    
+        ├── sys/
+    
+        ├── dev/
+    
+        └── usr/
+    
+            ├── bin/
+        
+            ├── sbin/
+        
+            ├── lib/
+        
+            └── lib64/

--- a/scripts/rootfs.sh
+++ b/scripts/rootfs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Phase 1: Create Root Filesystem
+# The purpose of this step is to set up the root filesystem structure according to the FHS (Filesystem Hierarchy Standard).
+
+# Create essential directories
+mkdir -p root/{boot,proc,sys,usr/{bin,sbin,lib,lib64},dev}
+# In this step, we create the core directories such as /bin, /usr/bin, etc.,
+# which will contain binaries and system programs.
+
+
+
+# Create symbolic links for compatibility with traditional root filesystem layout
+# These links ensure that binaries and libraries located in /usr are accessible from the root (/),
+# which is important for systems that expect /bin, /lib, and /sbin to exist directly under /
+
+# ⚠️ Note: Make sure you are inside the root filesystem directory before running these commands,
+# for example: cd /home/user/Tiny_linux/root
+
+ln -s usr/lib    lib     # Link /lib    -> /usr/lib
+ln -s usr/lib64  lib64   # Link /lib64  -> /usr/lib64
+ln -s usr/bin    bin     # Link /bin    -> /usr/bin
+ln -s usr/sbin   sbin    # Link /sbin   -> /usr/sbin
+
+# Export the path to the root filesystem for reuse in build scripts or other commands
+export MINI="/home/uesr/Tiny_linux/root"


### PR DESCRIPTION
This PR adds the initial root filesystem layout required for bootstrapping the minimal Linux environment.

## Changes
- Created `Tiny_linux/root/` directory tree:
  - `bin/`
  - `etc/`
  - `dev/`
  - `proc/`
  - `sys/`
  - `usr/`
- Added placeholder `.keep` files (if needed) to keep empty folders tracked.

## Motivation
This structure is necessary to allow user-space binaries like `init`, `sh`, and others to operate correctly, and to follow expected Linux conventions.

## Related Issue
Closes #1 
