### PR TITLE
Feature: Build and Install GNU Bash

### DIFF
--- a/docs/build_bash.md
+++ b/docs/build_bash.md
@@ -1,0 +1,63 @@
+# Building and Installing GNU Bash for the Mini Linux Project
+
+This guide explains how to clone, build, and install the GNU Bash shell into your minimal Linux environment.
+
+## Prerequisites
+
+Make sure the following tools are installed:
+
+- `git`
+- `gcc`
+- `make`
+
+## Steps
+
+### 1. Clone the Bash Source Code
+
+We use the official GNU Savannah repository:
+
+
+
+```bash
+git clone git://git.savannah.gnu.org/bash.git
+```
+
+### 2. Create a Separate Build Directory
+
+This helps keep the source clean:
+
+```bash
+mkdir bash-build
+cd bash-build
+```
+
+### 3. Explore Configuration Options (Optional)
+```bash
+../bash/configure --help
+```
+
+### 4. Configure the Build
+
+We install Bash to /usr inside our root filesystem later:
+
+```bash
+../bash/configure --prefix=/usr
+```
+
+### 5. Compile
+```bash
+make -j$(nproc)
+```
+### 6. Install into Root Filesystem
+
+Assuming $MINI points to your root directory (e.g., /home/user/Tiny_linux/root):
+
+```bash
+make DESTDIR=$MINI install
+```
+### 7. Set /bin/sh as a Symlink to Bash
+
+```bash
+ln -s bash root/bin/sh
+```
+Now your system has a basic shell installed.

--- a/scripts/build_bash.sh
+++ b/scripts/build_bash.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+# Define your root filesystem path
+MINI="/home/user/Tiny_linux/root"
+
+# Clone Bash source code
+git clone git://git.savannah.gnu.org/bash.git
+
+# Create and move to build directory
+mkdir -p bash-build
+cd bash-build
+
+# Configure Bash to install under /usr
+../bash/configure --prefix=/usr
+
+# Compile using 8 threads
+make -j$(nproc)
+
+# Install Bash to root filesystem
+make DESTDIR="$MINI" install
+cd ..
+
+# Create symlink: /bin/sh -> bash
+ln -sf bash "$MINI/bin/sh"
+
+echo "✅ Bash built and installed successfully."


### PR DESCRIPTION
 This PR adds a minimal setup for GNU Bash in the tiny Linux system. 

Included steps:

-    Cloned bash from GNU Savannah.

-    Built bash in a separate directory.

-    Installed it to `$MINI/usr`.

-    Added a symlink from `/bin/sh` to bash.

Closes #5 