### PR TITLE
🔧 Fix glibc build failure by adding GCC 16 build support and scripts

### DIFF
--- a/docs/build-gcc.md
+++ b/docs/build-gcc.md
@@ -1,0 +1,155 @@
+# Documentation: Building GCC Manually on CentOS Stream 9 Without Replacing the System Version
+
+This guide walks through **cloning, configuring, building, and installing GCC** from source on **CentOS Stream 9** without overwriting the system’s built-in version.
+
+---
+
+## 🛠 Why Build a Custom GCC Version?
+
+The default GCC version in CentOS Stream 9 is 11.5, which does not meet the minimum requirement (GCC ≥ 12) for building the latest GNU C Library (glibc). Attempting to compile glibc with an older version leads to build failures.
+
+Since glibc is a critical component in my custom Linux system project, I built GCC from source to meet the necessary requirements and gain full control over the build process
+
+---
+
+## ✅ Benefits:
+
+-   Satisfies glibc’s minimum requirement (GCC ≥ 12).
+
+-   Provides access to modern compiler features and optimizations.
+
+-   Isolates the toolchain in $HOME/.local/gcc-16.0 to avoid system conflicts.
+
+-   Preserves system stability by keeping the default compiler untouched.
+
+-   Enables clean and reproducible builds in a controlled user-space environment.
+
+
+---
+
+## 🛠 Requirements
+
+### Install necessary development tools:
+
+```bash
+sudo dnf groupinstall "Development Tools"
+sudo dnf install gcc gcc-c++ git wget tar \
+    glibc-devel glibc-devel.i686 \
+    libstdc++-devel libstdc++-devel.i686 \
+    gmp-devel mpfr-devel libmpc-devel isl-devel \
+    zlib-devel
+```
+
+---
+
+## 📥 Clone GCC Source Code
+
+```bash
+git clone git://gcc.gnu.org/git/gcc.git gcc-src
+cd gcc-src
+./contrib/download_prerequisites
+cd ..
+```
+
+---
+
+## 📁 Create Build Directory (must be separate from source tree)
+
+```bash
+mkdir gcc-build
+cd gcc-build
+```
+
+---
+
+## ⚙️ Configure GCC Build
+
+```bash
+../gcc-src/configure \
+  --prefix=$HOME/.local/gcc-16.0 \
+  --enable-languages=c,c++ \
+  --disable-multilib \
+  --program-suffix=-16.0 \
+  --enable-checking=release \
+  --enable-threads=posix \
+  --enable-shared \
+  --enable-__cxa_atexit \
+  --with-system-zlib
+```
+
+### Explanation of Options:
+
+* `--prefix`: Target installation directory.
+* `--disable-multilib`: Avoids 32-bit support complications.
+* `--program-suffix`: Adds suffix to GCC binaries (e.g. `gcc-16.0`).
+
+---
+
+## 🧱 Build GCC
+**Important: Never run `make` inside the source directory.**
+
+```bash
+make -j$(nproc)
+```
+The make step takes a long time . if your build fails and your configure command has lots of complicated options you should try removing options and keep it simple. Do not add lots of configure options you don't understand, they might be the reason your build fails. 
+
+---
+
+## 📦 Install GCC
+
+```bash
+make install
+```
+
+Installed to: `$HOME/.local/gcc-16.0`
+
+---
+
+## 🔧 Set Up Environment Variables
+
+Add the following to your `~/.bashrc.d/gcc.sh` (or directly into `~/.bashrc`):
+
+```bash
+export PATH="$HOME/.local/gcc-16.0/bin:$PATH"
+export LD_LIBRARY_PATH="$HOME/.local/gcc-16.0/lib64"
+
+export CC="$HOME/.local/gcc-16.0/bin/gcc-16.0"
+export CXX="$HOME/.local/gcc-16.0/bin/g++-16.0"
+
+```
+
+Activate the environment:
+
+```bash
+source ~/.bashrc
+```
+
+---
+
+## ✅ Verify Installation
+
+```bash
+gcc-16.0 --version
+g++-16.0 --version
+```
+
+---
+
+## 📁 Directory Structure Used
+
+```
+~/
+├── gcc-src         # Source code
+├── gcc-build       # External build directory
+└── .local/gcc-16.0 # Final installation path
+```
+
+---
+
+## 🧠 Final Notes:
+
+* Use `gcc-16.0` explicitly in your projects to avoid confusion.
+* You can set up CMake or Meson to target this GCC version using environment variables or a toolchain file.
+* This custom installation has no effect on `dnf`, `rpm`, or any system-level tools.
+
+---

--- a/scripts/build-gcc.sh
+++ b/scripts/build-gcc.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+# Variables
+GCC_VERSION="16.0"
+INSTALL_DIR="$HOME/.local/gcc-$GCC_VERSION"
+SRC_DIR="$HOME/gcc-src"
+BUILD_DIR="$HOME/gcc-build"
+
+echo "🔧 Installing prerequisites..."
+sudo dnf groupinstall -y "Development Tools"
+sudo dnf install -y \
+  gcc gcc-c++ git wget tar \
+  glibc-devel glibc-devel.i686 \
+  libstdc++-devel libstdc++-devel.i686 \
+  gmp-devel mpfr-devel libmpc-devel isl-devel \
+  zlib-devel
+
+echo "📥 Cloning GCC source code..."
+git clone git://gcc.gnu.org/git/gcc.git "$SRC_DIR"
+cd "$SRC_DIR"
+./contrib/download_prerequisites
+cd ..
+
+echo "📁 Creating build directory..."
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+echo "⚙️ Configuring GCC build..."
+"$SRC_DIR/configure" \
+  --prefix="$INSTALL_DIR" \
+  --enable-languages=c,c++ \
+  --disable-multilib \
+  --program-suffix="-$GCC_VERSION" \
+  --enable-checking=release \
+  --enable-threads=posix \
+  --enable-shared \
+  --enable-__cxa_atexit \
+  --with-system-zlib
+
+echo "🧱 Building GCC... this may take a while"
+make -j"$(nproc)"
+
+echo "📦 Installing GCC to $INSTALL_DIR"
+make install
+
+echo "✅ Done. Add the following to your environment:"
+echo
+echo "export PATH=\"$INSTALL_DIR/bin:\$PATH\""
+echo "export LD_LIBRARY_PATH=\"$INSTALL_DIR/lib64:\$LD_LIBRARY_PATH\""
+echo "export CC=\"$INSTALL_DIR/bin/gcc-$GCC_VERSION\""
+echo "export CXX=\"$INSTALL_DIR/bin/g++-$GCC_VERSION\""
+


### PR DESCRIPTION
This PR introduces a solution to the glibc build failure caused by the outdated GCC version in CentOS Stream 9.

What's included:

- Shell script: `scripts/build-gcc.sh`
- Documentation: how to build and install GCC 16 safely in user-space
- Environment setup instructions
- Integration notes for glibc and toolchain compatibility

GCC is installed to `$HOME/.local/gcc-16.0` and does not interfere with system GCC.

Closes #7 
Closes #8 
