### PR TITLE
[Docs] Add glibc manual build guide and troubleshooting notes

### DIFF
--- a/docs/build-glibc.md
+++ b/docs/build-glibc.md
@@ -1,0 +1,105 @@
+# 🧱 Building the GNU C Library (glibc) from Source
+
+## 📘 What is glibc?
+
+**glibc** (GNU C Library) is the **core component** of any GNU/Linux system. It provides the standard C library interfaces used by almost all user-space programs — including basic I/O, memory allocation, process creation, threading, localization, and more.
+
+At runtime, glibc also provides:
+
+-    The **dynamic linker/loader** (`ld-linux.so`), which loads shared libraries.
+
+-    The implementation of essential system calls and standard library functions.
+
+-    Compatibility infrastructure for cross-platform development.
+
+In short, no serious Linux system works without glibc. It's the glue between your programs and the Linux kernel.
+
+---
+
+## 🎯 Why build glibc manually?
+
+If you're building a custom Linux system, or experimenting with toolchains, it may be necessary to build glibc yourself. This gives you:
+
+-    Full control over configuration options and paths.
+
+-    Ability to use newer versions than your distribution provides.
+
+-    A clean, isolated user-space environment decoupled from the host.
+
+---
+
+## ⚠️ Important: GCC Requirements
+
+Recent versions of **glibc** require **GCC 12 or higher** to compile. Some distributions (e.g., CentOS Stream 9) only ship with GCC 11.x, which is insufficient.
+
+✅ If your system's compiler is GCC ≥ 12, you may **skip** building GCC manually.
+
+If not, you’ll need to [build a custom GCC](build-gcc.md) and **export it properly** in your environment. Example :
+```bash
+export PATH="$HOME/.local/gcc-16.0/bin:$PATH"
+export LD_LIBRARY_PATH="$HOME/.local/gcc-16.0/lib64"
+```
+---
+## 🛑 Common Errors When Using a Custom GCC:
+
+**1. crt1.o / crti.o not found**  
+  → Missing 32-bit dev libraries (`glibc-devel` or `glibc-devel.i686`).
+
+**2. LD_LIBRARY_PATH contains the current directory (.)**  
+  → Remove `.` from `LD_LIBRARY_PATH` before running `configure`.  
+    This can happen if `:` appears at the start or end of the variable.
+Example:
+```bash
+export LD_LIBRARY_PATH=$(echo "$LD_LIBRARY_PATH" | sed 's/^://;s/:$//')
+```
+---
+
+## 🔧 Build Instructions
+
+**1. Clone the glibc source:**
+```bash
+git clone git://sourceware.org/git/glibc.git
+```
+
+**2. Create a build directory:**
+```bash
+mkdir glibc-build
+cd glibc-build
+```
+🛠 glibc **must be built outside** the source tree.
+
+**3. Configure the build:**
+```bash
+../glibc/configure --prefix=/usr --libdir=/lib
+```
+
+-    `--prefix=/usr`: install glibc into the standard system root.
+
+-    `--libdir=/lib`: ensures core libraries are placed in `/lib` .
+
+
+**4. Compile:**
+
+```bash
+make -j$(nproc)
+```
+
+**5. Install into target directory:**
+
+```bash
+make DESTDIR=$MINI install
+```
+`$MINI` should point to the root of your custom Linux system (e.g., `$HOME/Tiny_linux/root`).
+
+---
+
+## ✅ Summary
+
+ -   glibc is essential for every Linux-based system.
+
+ -   Building glibc manually gives you full control over system behavior.
+
+ -   A modern GCC (≥ 12) is required; older compilers will fail.
+
+ -   Errors often relate to missing libraries or misconfigured environments — fix them early to save time
+

--- a/scripts/build-glibc.sh
+++ b/scripts/build-glibc.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# build-glibc.sh: Build and install glibc using custom GCC
+
+set -e
+
+# === Configuration ===
+GLIBC_REPO="git://sourceware.org/git/glibc.git"
+GLIBC_SRC="glibc"
+GLIBC_BUILD="glibc-build"
+INSTALL_PREFIX="/usr"
+LIBDIR="/lib"
+
+# === Custom toolchain path ===
+export MINI="$HOME/Tiny_linux/root"
+export GCC_PATH="$HOME/.local/gcc-16.0"
+export PATH="$GCC_PATH/bin:$PATH"
+export LD_LIBRARY_PATH="$GCC_PATH/lib64"
+
+# === Optional cleanup ===
+rm -rf "$GLIBC_SRC" "$GLIBC_BUILD"
+
+# === Clone source ===
+git clone "$GLIBC_REPO" "$GLIBC_SRC"
+
+# === Create build directory ===
+mkdir "$GLIBC_BUILD"
+cd "$GLIBC_BUILD"
+
+# === Configure ===
+"../$GLIBC_SRC/configure" \
+  --prefix="$INSTALL_PREFIX" \
+  --libdir="$LIBDIR"
+
+# === Compile ===
+make -j"$(nproc)"
+
+# === Install ===
+make DESTDIR="$MINI" install
+
+echo "✅ glibc built and installed into $MINI"
+


### PR DESCRIPTION
This PR adds comprehensive documentation for manually building glibc from source using a custom toolchain, targeting CentOS Stream 9. It includes:

-    GCC version requirement and custom environment setup

-    Complete build instructions: clone, configure, compile, and install

-    Common pitfalls like crt1.o and LD_LIBRARY_PATH issues

-    Integration into $MINI Linux rootfs for isolation

This PR assumes GCC ≥ 12 has already been built and available at $HOME/.local/gcc-16.0.

Closes: #10  (Build glibc from source using custom GCC)