### PR TITLE
Add util-linux build support to Tiny_linux

### DIFF
--- a/docs/build_util_linux.md
+++ b/docs/build_util_linux.md
@@ -1,0 +1,143 @@
+
+# Building and Installing util-linux: Essential Linux Tools from Source 🛠️
+
+The **util-linux** package is a collection of indispensable utilities for Linux-based systems. These utilities are essential for system administration, disk management, and handling filesystems. They are fundamental tools that every Linux user and administrator relies on to manage and maintain the system effectively. Whether you're mounting filesystems, partitioning disks, or managing processes, these tools form the backbone of system management. 💻
+
+## Key Utilities in util-linux:
+
+-    **mount**: This command is used to mount filesystems, allowing you to attach devices or filesystems to the overall filesystem tree. 🗂️
+
+-    **umount**: The opposite of mount, this command unmounts filesystems that were previously mounted. 🧹
+
+-    **fdisk**: A powerful utility for partitioning disk drives, enabling efficient disk space management. 💾
+
+-    **login**: Manages user logins to the system, ensuring secure access for users. 🔐
+
+-    **kill**: Sends signals to processes, allowing you to control or terminate them as needed. 🚨
+
+-    **chroot**: Changes the root directory for the current process and its children. It's a vital tool for system recovery and repairs. 🔄
+
+-    **lsblk**: Lists information about block devices like disks and partitions, helping you understand your system’s hardware. 📊
+
+-    **dmesg**: Displays or controls the kernel ring buffer, showing messages related to your system's hardware and kernel. 📜
+
+---
+
+##  Why util-linux Is Essential 🌟
+
+These tools are crucial because they provide the core functionality needed to manage Linux systems at a low level. Without them, tasks such as managing filesystems, partitions, user logins, and system processes would become much more challenging. They are indispensable for:
+
+-    **System Recovery**: Tools like `chroot` and `dmesg` are essential when recovering from system crashes or repairing a damaged system. ⚒️
+
+-    **Disk Management**: Commands like `mount`, `umount`, and `fdisk` are vital for managing storage devices, partitions, and filesystems. 🛠️
+
+-    **System Monitoring**: Utilities like `lsblk` and `dmesg` help administrators monitor the system’s hardware and kernel messages, providing valuable insights. 👀
+
+**util-linux** is the standard suite included in most Linux distributions, ensuring consistency and compatibility across different systems. This makes it easier for system administrators to manage multiple Linux environments with the same tools. 🔄
+
+## Steps to Build and Install util-linux 🏗️
+
+Here is the process we followed to download, build, and install the **util-linux** utilities from source:
+
+---
+
+### 📥 1. Clone the Repository
+
+We started by cloning the util-linux repository from GitHub to get the latest version of the source code:
+
+```bash
+git clone --depth 1 https://github.com/util-linux/util-linux
+```
+
+By using the `--depth 1` option, we limited the clone to the most recent commit, saving both time and space by excluding the full commit history.
+
+---
+
+## 🛠️ 2. Prepare the Build Directory
+
+Next, we created a new directory where we would configure and compile the utilities:
+
+```bash
+mkdir util-build
+```
+
+---
+
+## 🔧 3. Run the `autogen.sh` Script
+
+The `autogen.sh` script generates the configuration files required to set up the build system. This step is essential before compiling the utilities:
+
+```bash
+cd util-linux
+./autogen.sh
+cd ..
+```
+
+---
+
+## ⚙️ 4. Configure the Build
+
+At this point, we configured the build system with the necessary flags. For instance, we used `--disable-liblastlog2` to exclude the `lastlog2` library (which we didn’t need), and `--prefix=/usr` to ensure the utilities are installed in the standard `/usr` directory.
+
+```bash
+cd util-build
+../util-linux/configure --disable-liblastlog2 --prefix=/usr
+```
+
+---
+
+## 🏗️ 5. Build the Utilities
+
+After configuring the build system, we used `make` to compile the utilities. The `-j$(nproc)` flag helps speed up the process by utilizing all available CPU cores:
+
+```bash
+make -j$(nproc)
+```
+
+---
+
+## 💾 6. Install the Utilities
+
+Finally, we installed the built utilities into the system. The `DESTDIR=$MINI install` command installs them into the specified directory, which is typically used for packaging or testing purposes:
+
+```bash
+make DESTDIR=$MINI install
+```
+
+**Note**: `$MINI` should point to the root path of your mini Linux system (e.g., `/home/user/Tiny_linux/root`).
+
+---
+
+## 🗂️ 7. Verify Installed Tools
+
+After installation, we verified the tools by checking the contents of `/usr/bin/`:
+
+```bash
+ls $MINI/usr/bin
+```
+
+You should now see core utilities like `ls`, `cp`, `mv`, `rm`, `cat`, and more.
+
+---
+
+### 📋 Checklist of Tasks
+
+- [x]    Clone the **util-linux** repository.
+
+- [x]    Prepare the build directory.
+
+- [x]    Run `autogen.sh` to generate configuration files.
+
+- [x]    Configure the build with necessary flags.
+
+- [x]    Compile the utilities using `make`.
+
+- [x]    Install the utilities into the system.
+
+- [x]    Verify the installed tools in `/usr/bin/`.
+
+---
+
+### 💡 Why These Steps Matter
+
+This process allows you to build and install essential Linux utilities from source, ensuring that you can customize your system setup or recovery process without depending on precompiled packages. This flexibility is crucial for developers, system administrators, or anyone working with minimal Linux setups. 🛠️

--- a/scripts/build_util_linux.sh
+++ b/scripts/build_util_linux.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# Set the root install path
+MINI=${MINI:-"$HOME/Tiny_linux/root"}
+
+REPO="https://github.com/util-linux/util-linux"
+SRC_DIR="util-linux"
+BUILD_DIR="util-build"
+
+echo "📥 Cloning util-linux..."
+git clone --depth 1 "$REPO" "$SRC_DIR"
+
+echo "🔧 Running autogen.sh..."
+cd "$SRC_DIR"
+./autogen.sh
+cd ..
+
+echo "🏗️ Preparing build directory..."
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+echo "⚙️ Configuring util-linux..."
+../"$SRC_DIR"/configure --disable-liblastlog2 --prefix=/usr
+
+echo "🛠️ Building util-linux..."
+make -j"$(nproc)"
+
+echo "💾 Installing into $MINI..."
+make DESTDIR="$MINI" install
+
+echo "✅ util-linux built and installed successfully."
+


### PR DESCRIPTION
This PR adds a build script for util-linux to the Tiny_linux project.
    It compiles and installs essential system tools such as `mount`, `fdisk`, `kill`, and `chroot`.

-    Uses autogen.sh to prepare the build system 
  
-     Configured with --disable-liblastlog2 to minimize dependencies

-     Installs into $MINI

    📂 Script: scripts/build_util_linux.sh

    Closes #14 